### PR TITLE
add rust_analyzer capabilities

### DIFF
--- a/content/posts/neovim-rust.md
+++ b/content/posts/neovim-rust.md
@@ -132,6 +132,11 @@ set shortmess+=c
 lua <<EOF
 local nvim_lsp = require'lspconfig'
 
+local capabilities = require('cmp_nvim_lsp').default_capabilities()
+require('lspconfig')['rust_analyzer'].setup {
+  capabilities = capabilities
+}
+
 local opts = {
     tools = { -- rust-tools options
         autoSetHints = true,


### PR DESCRIPTION
Suggestions for automatically importing functions defined in other files when the name of that function is entered do not appear. Adding `capabilities` fixes this.